### PR TITLE
Add initial MRI assistant MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/app.py
+++ b/app.py
@@ -1,0 +1,40 @@
+"""MRI Reading Assistant MVP using Streamlit."""
+import os
+import tempfile
+
+import streamlit as st
+import ants
+
+from mri_app.image_utils import extract_brain
+from mri_app.openai_client import OpenAIClient
+
+
+def main():
+    st.title("MRI Reading Assistant")
+
+    uploaded = st.file_uploader("Upload NIfTI image", type=["nii", "nii.gz"])
+    if uploaded is None:
+        st.info("Please upload an MRI file.")
+        return
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".nii.gz") as tmp:
+        tmp.write(uploaded.read())
+        tmp_path = tmp.name
+
+    try:
+        st.info("Performing brain extraction...")
+        masked = extract_brain(tmp_path)
+        st.image(masked.numpy(), caption="Extracted brain")
+
+        client = OpenAIClient()
+        st.info("Sending to GPT-4.1...")
+        response = client.analyze_image(tmp_path)
+        st.markdown(response.report)
+    except Exception as e:
+        st.error(f"Processing failed: {e}")
+    finally:
+        os.remove(tmp_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/mri_app/image_utils.py
+++ b/mri_app/image_utils.py
@@ -1,0 +1,9 @@
+import ants
+from antspynet.utilities import brain_extraction
+
+
+def extract_brain(image_path: str) -> ants.ANTsImage:
+    """Run brain extraction and return masked image."""
+    img = ants.image_read(image_path)
+    mask = brain_extraction(img)
+    return img * mask

--- a/mri_app/openai_client.py
+++ b/mri_app/openai_client.py
@@ -1,0 +1,34 @@
+import os
+from typing import Dict, Any
+import openai
+from pydantic import BaseModel
+
+class GPTResponse(BaseModel):
+    report: str
+
+class OpenAIClient:
+    def __init__(self, api_key_env: str = "OPENAI_API_KEY"):
+        key = os.getenv(api_key_env)
+        if not key:
+            raise ValueError(f"Environment variable {api_key_env} is not set")
+        openai.api_key = key
+
+    def analyze_image(self, image_path: str) -> GPTResponse:
+        try:
+            with open(image_path, "rb") as f:
+                response = openai.ChatCompletion.create(
+                    model="gpt-4-vision-preview",
+                    messages=[
+                        {"role": "system", "content": "You are a radiology assistant."},
+                        {"role": "user", "content": "Analyze this MRI image."}
+                    ],
+                    files=[{"file": f}]
+                )
+        except Exception as e:
+            raise RuntimeError(f"OpenAI API call failed: {e}") from e
+
+        try:
+            data = GPTResponse(**{"report": response["choices"][0]["message"]["content"]})
+            return data
+        except Exception as e:
+            raise ValueError(f"Invalid response format: {e}") from e

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+antspynet
+ants
+openai
+pydantic

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,10 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+from mri_app.openai_client import OpenAIClient
+import pytest
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        OpenAIClient()


### PR DESCRIPTION
## Summary
- start implementing MRI reading assistant MVP
- add Streamlit app with OpenAI client and ANTsPyNet utilities
- create basic test to verify API key requirement
- set up requirements and gitignore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685969b2e76883338aeef6ac1f406428