### PR TITLE
Improve OpenAI client and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Environment variables for MRI Reading Assistant
+OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# agent_mri
+# MRI Reading Assistant
+
+This project is an example MVP combining **ANTsPyNet** and **GPT-4.1**.  
+It provides a simple Streamlit application to upload an MRI image, run brain
+extraction and request a textual report from OpenAI.
+
+## Setup
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Prepare environment variables.  Copy `.env.example` and set your
+   `OPENAI_API_KEY`.
+
+3. Launch the application
+   ```bash
+   streamlit run app.py
+   ```
+
+Unit tests can be executed with `pytest`.

--- a/mri_app/image_utils.py
+++ b/mri_app/image_utils.py
@@ -1,9 +1,27 @@
+"""Utilities for MRI image analysis using ANTsPyNet."""
+
 import ants
 from antspynet.utilities import brain_extraction
 
 
-def extract_brain(image_path: str) -> ants.ANTsImage:
-    """Run brain extraction and return masked image."""
-    img = ants.image_read(image_path)
-    mask = brain_extraction(img)
+def extract_brain(image_path: str) -> ants.ANTsImage | None:
+    """Run brain extraction and return masked image.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to a NIfTI image on disk.
+
+    Returns
+    -------
+    ants.ANTsImage | None
+        Masked image or ``None`` if extraction failed.
+    """
+
+    try:
+        img = ants.image_read(image_path)
+        mask = brain_extraction(img)
+    except Exception:
+        return None
+
     return img * mask

--- a/mri_app/openai_client.py
+++ b/mri_app/openai_client.py
@@ -1,10 +1,20 @@
+"""OpenAI client for MRI report generation."""
+
+import json
 import os
-from typing import Dict, Any
+from typing import Any
+
 import openai
 from pydantic import BaseModel
 
-class GPTResponse(BaseModel):
-    report: str
+class GPTReport(BaseModel):
+    """Structured response from GPT."""
+
+    is_finding_present: bool
+    finding_summary: str | None = None
+    detailed_description: str | None = None
+    confidence_score: float
+    anatomical_location: str | None = None
 
 class OpenAIClient:
     def __init__(self, api_key_env: str = "OPENAI_API_KEY"):
@@ -13,22 +23,25 @@ class OpenAIClient:
             raise ValueError(f"Environment variable {api_key_env} is not set")
         openai.api_key = key
 
-    def analyze_image(self, image_path: str) -> GPTResponse:
+    def analyze_image(self, image_path: str) -> GPTReport:
+        """Send an MRI image to GPT and parse JSON report."""
+
         try:
             with open(image_path, "rb") as f:
                 response = openai.ChatCompletion.create(
                     model="gpt-4-vision-preview",
                     messages=[
                         {"role": "system", "content": "You are a radiology assistant."},
-                        {"role": "user", "content": "Analyze this MRI image."}
+                        {"role": "user", "content": "Analyze this MRI image and reply in JSON."},
                     ],
-                    files=[{"file": f}]
+                    files=[{"file": f}],
                 )
         except Exception as e:
             raise RuntimeError(f"OpenAI API call failed: {e}") from e
 
         try:
-            data = GPTResponse(**{"report": response["choices"][0]["message"]["content"]})
-            return data
+            content: str = response["choices"][0]["message"]["content"]
+            data: Any = json.loads(content)
+            return GPTReport.model_validate(data)
         except Exception as e:
             raise ValueError(f"Invalid response format: {e}") from e

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,51 @@
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import json
+import tempfile
+import pytest
+
+from mri_app.openai_client import OpenAIClient, GPTReport
+
+class DummyResponse(dict):
+    pass
+
+
+def test_parse_valid_response(monkeypatch):
+    resp_json = {
+        "is_finding_present": False,
+        "finding_summary": None,
+        "detailed_description": None,
+        "confidence_score": 0.9,
+        "anatomical_location": None,
+    }
+    dummy = DummyResponse({"choices": [{"message": {"content": json.dumps(resp_json)}}]})
+
+    def fake_create(*args, **kwargs):
+        return dummy
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
+
+    client = OpenAIClient()
+    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp:
+        report = client.analyze_image(tmp.name)
+
+    assert isinstance(report, GPTReport)
+    assert report.is_finding_present is False
+
+
+def test_invalid_json(monkeypatch):
+    dummy = DummyResponse({"choices": [{"message": {"content": "not-json"}}]})
+
+    def fake_create(*args, **kwargs):
+        return dummy
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
+
+    client = OpenAIClient()
+    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp:
+        with pytest.raises(ValueError):
+            client.analyze_image(tmp.name)


### PR DESCRIPTION
## Summary
- implement `GPTReport` schema and parse GPT responses
- add error handling in image analyzer
- document setup instructions
- provide `.env.example`
- add tests for the OpenAI client

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68596c278c84833388218bc12a29ca53