### PR TITLE
Fix tests by pinning openai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit
 antspynet
 ants
-openai
+openai==0.28
 pydantic


### PR DESCRIPTION
## Summary
- pin `openai` dependency to version `0.28` for backward compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685970b767308333b15f30890f7f9f31