### PR TITLE
Improve OpenAI client error handling

### DIFF
--- a/mri_app/image_utils.py
+++ b/mri_app/image_utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 _ALLOWED_EXTS = {".nii", ".nii.gz", ".png", ".jpg", ".jpeg"}
 
 def is_supported_file(path: str) -> bool:
-    """Return ``True`` if file has a supported extension."""
+    """Return ``True`` if ``path`` has a supported medical image extension."""
     ext = Path(path).suffix.lower()
     if ext == ".gz":
         ext = Path(path).with_suffix("").suffix.lower() + ".gz"

--- a/mri_app/openai_client.py
+++ b/mri_app/openai_client.py
@@ -7,6 +7,8 @@ from typing import Any
 import openai
 from pydantic import BaseModel
 
+from .image_utils import is_supported_file
+
 class GPTReport(BaseModel):
     """Structured response from GPT."""
 
@@ -25,6 +27,12 @@ class OpenAIClient:
 
     def analyze_image(self, image_path: str) -> GPTReport:
         """Send an MRI image to GPT and parse JSON report."""
+
+        if not os.path.isfile(image_path):
+            raise FileNotFoundError(image_path)
+
+        if not is_supported_file(image_path):
+            raise ValueError(f"Unsupported file type: {image_path}")
 
         try:
             with open(image_path, "rb") as f:


### PR DESCRIPTION
## Summary
- handle missing file path in `OpenAIClient.analyze_image`
- give clearer error message when extension is not supported
- document intent of `is_supported_file`
- test file not found case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859f75271c88333a0fce71166ebb10d