### PR TITLE
Add mask overlay and update brain extraction API

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import tempfile
 import streamlit as st
 import ants
 
-from mri_app.image_utils import extract_brain
+from mri_app.image_utils import extract_brain, overlay_mask
 from mri_app.openai_client import OpenAIClient
 
 
@@ -23,8 +23,12 @@ def main():
 
     try:
         st.info("Performing brain extraction...")
-        masked = extract_brain(tmp_path)
-        st.image(masked.numpy(), caption="Extracted brain")
+        result = extract_brain(tmp_path)
+        if result is None:
+            st.error("Brain extraction failed.")
+            return
+        image, mask = result
+        st.image(overlay_mask(image, mask), caption="Extracted brain")
 
         client = OpenAIClient()
         st.info("Sending to GPT-4.1...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ antspynet
 ants
 openai==0.28
 pydantic
+numpy


### PR DESCRIPTION
## Summary
- add new `overlay_mask` helper and adjust `extract_brain` to return image and mask
- show overlay in the Streamlit app
- include numpy dependency
- extend image utility tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ff6b94dc833399c0599c3b53dd92