### PR TITLE
Enhance OpenAI client with mask support

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,12 @@ def main():
 
         client = OpenAIClient()
         st.info("Sending to GPT-4.1...")
-        response = client.analyze_image(tmp_path)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".nii.gz") as mtmp:
+            ants.image_write(mask, mtmp.name)
+            mask_path = mtmp.name
+
+        response = client.analyze_image(tmp_path, mask_path)
+        os.remove(mask_path)
         st.markdown(response.report)
     except Exception as e:
         st.error(f"Processing failed: {e}")

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -29,8 +29,9 @@ def test_parse_valid_response(monkeypatch):
     monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
 
     client = OpenAIClient()
-    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp:
-        report = client.analyze_image(tmp.name)
+    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp1, \
+         tempfile.NamedTemporaryFile(suffix=".nii") as tmp2:
+        report = client.analyze_image(tmp1.name, tmp2.name)
 
     assert isinstance(report, GPTReport)
     assert report.is_finding_present is False
@@ -46,9 +47,10 @@ def test_invalid_json(monkeypatch):
     monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
 
     client = OpenAIClient()
-    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp1, \
+         tempfile.NamedTemporaryFile(suffix=".nii") as tmp2:
         with pytest.raises(ValueError):
-            client.analyze_image(tmp.name)
+            client.analyze_image(tmp1.name, tmp2.name)
 
 
 def test_api_error(monkeypatch):
@@ -59,9 +61,10 @@ def test_api_error(monkeypatch):
     monkeypatch.setattr("openai.ChatCompletion.create", fake_create)
 
     client = OpenAIClient()
-    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp1, \
+         tempfile.NamedTemporaryFile(suffix=".nii") as tmp2:
         with pytest.raises(RuntimeError):
-            client.analyze_image(tmp.name)
+            client.analyze_image(tmp1.name, tmp2.name)
 
 
 def test_unsupported_extension(monkeypatch):


### PR DESCRIPTION
## Summary
- allow `OpenAIClient.analyze_image` to accept an optional mask image
- upload the brain mask when calling OpenAI from the Streamlit app
- update tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a017fe3fc8333b2dee127efa8a0a9