### PR TITLE
Add model_dump_json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ the application for the first time.
    streamlit run app.py
    ```
 
+After processing an image the app shows the extracted brain, textual findings
+and offers a **Download JSON** button to save the structured report.
+
 Unit tests can be executed with `pytest`.
 
 The results shown by the application are intended for assisting radiologists

--- a/app.py
+++ b/app.py
@@ -48,6 +48,13 @@ def main():
         else:
             st.markdown("**所見:** 異常所見は検出されませんでした。")
 
+        st.download_button(
+            label="Download JSON",
+            data=response.to_json(),
+            file_name="report.json",
+            mime="application/json",
+        )
+
         st.markdown("*本結果はAIによる補助情報であり、診断は専門医が行ってください*")
     except Exception as e:
         st.error(f"Processing failed: {e}")

--- a/mri_app/openai_client.py
+++ b/mri_app/openai_client.py
@@ -19,6 +19,10 @@ class GPTReport(BaseModel):
     confidence_score: float
     anatomical_location: str | None = None
 
+    def to_json(self) -> str:
+        """Return the report as a JSON string."""
+        return self.model_dump_json(ensure_ascii=False)
+
 class OpenAIClient:
     def __init__(self, api_key_env: str = "OPENAI_API_KEY"):
         key = os.getenv(api_key_env)

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -6,3 +6,13 @@ class BaseModel:
     @classmethod
     def model_validate(cls, data):
         return cls(**data)
+
+    def model_dump(self):
+        """Return model data as a plain ``dict``."""
+        return {field: getattr(self, field) for field in self.__annotations__}
+
+    def model_dump_json(self, **kwargs):
+        """Return model data serialized to JSON."""
+        import json
+
+        return json.dumps(self.model_dump(), **kwargs)

--- a/streamlit/__init__.py
+++ b/streamlit/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "warning",
     "success",
     "write",
+    "download_button",
     "spinner",
     "session_state",
 ]
@@ -76,6 +77,11 @@ def success(*args, **kwargs):
 
 
 def write(*args, **kwargs):
+    return None
+
+
+def download_button(*args, **kwargs):
+    """Return ``None`` for ``st.download_button`` in tests."""
     return None
 
 

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -53,6 +53,20 @@ def test_parse_report_helper():
     assert report.is_finding_present is True
 
 
+def test_report_to_json():
+    """GPTReport should serialize to JSON string."""
+
+    report = GPTReport(
+        is_finding_present=True,
+        finding_summary="s",
+        detailed_description="d",
+        confidence_score=0.7,
+        anatomical_location="brain",
+    )
+    data = json.loads(report.to_json())
+    assert data["is_finding_present"] is True
+
+
 def test_parse_report_missing_key():
     """parse_report should fail when required keys are missing."""
     text = json.dumps({"confidence_score": 0.1})


### PR DESCRIPTION
## Summary
- expand pydantic stub with `model_dump` and `model_dump_json`
- refactor `GPTReport.to_json` to use `model_dump_json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4817cf4c83338bdb996777802296