### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ the application for the first time.
    ```bash
    pip install -r requirements.txt
    ```
-2. Prepare environment variables.  Copy `.env.example` and set your
-   `OPENAI_API_KEY`.
+2. Prepare environment variables.  Copy `.env.example` to `.env` and set your
+   `OPENAI_API_KEY`.  The application automatically loads this file via
+   `python-dotenv`.
 
 3. Launch the application
    ```bash

--- a/app.py
+++ b/app.py
@@ -36,7 +36,13 @@ def main():
         with img_col:
             st.image(overlay_mask(image, mask), caption="Extracted brain")
 
-        client = get_openai_client()
+        try:
+            client = get_openai_client()
+        except ValueError:
+            st.error(
+                "APIキーが見つかりません。環境変数OPENAI_API_KEYを設定してください。"
+            )
+            return
         st.info("Sending to GPT-4.1...")
         with tempfile.NamedTemporaryFile(delete=False, suffix=".nii.gz") as mtmp:
             ants.image_write(mask, mtmp.name)

--- a/mri_app/__init__.py
+++ b/mri_app/__init__.py
@@ -1,1 +1,10 @@
 # -*- coding: utf-8 -*-
+"""MRI app package initialization."""
+
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present. Existing variables are
+# not overwritten. This allows developers to configure OPENAI_API_KEY locally
+# without modifying code.
+load_dotenv()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ants
 openai==0.28
 pydantic
 numpy
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- document `.env` usage in README
- include `python-dotenv` in requirements
- show error when `OPENAI_API_KEY` is missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a9e19ffe083339d66712cbe95fce8