### PR TITLE
Minor overlay validation

### DIFF
--- a/mri_app/image_utils.py
+++ b/mri_app/image_utils.py
@@ -106,16 +106,18 @@ def overlay_mask(image: "ants.ANTsImage", mask: "ants.ANTsImage", color: tuple[i
     np.ndarray
         RGB image array suitable for ``st.image``.
     """
-
     img_np = image.numpy().astype(float)
+    mask_np = mask.numpy() > 0
+
+    if img_np.shape != mask_np.shape:
+        raise ValueError("image and mask shapes do not match")
+
     img_np -= img_np.min()
     maxv = img_np.max()
     if maxv > 0:
         img_np /= maxv
     img_uint8 = (img_np * 255).astype(np.uint8)
     rgb = np.stack([img_uint8] * 3, axis=-1)
-
-    mask_np = mask.numpy() > 0
     for i, c in enumerate(color):
         rgb[..., i][mask_np] = c
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -6,6 +6,7 @@ import tempfile
 from mri_app import image_utils
 import numpy as np
 from PIL import Image
+import pytest
 
 
 class DummyImage:
@@ -78,3 +79,12 @@ def test_overlay_mask_custom_color():
 
     arr = image_utils.overlay_mask(img, mask, color=(0, 255, 0))
     assert (arr == [0, 255, 0]).all()
+
+
+def test_overlay_mask_shape_mismatch():
+    """overlay_mask should error when shapes differ."""
+    img = DummyImage(np.zeros((2, 2)))
+    mask = DummyImage(np.zeros((1, 1)))
+
+    with pytest.raises(ValueError):
+        image_utils.overlay_mask(img, mask)


### PR DESCRIPTION
## Summary
- validate shapes match in `overlay_mask`
- test error case when shapes mismatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aac3a222c8333959074719ce8eecf